### PR TITLE
Adds `bundle exec rake` and `bundle exec rake spec`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,8 +20,10 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-
-
-
 Bundler::GemHelper.install_tasks
 
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec


### PR DESCRIPTION
For when you don't want to run Guard to run the tests
